### PR TITLE
updated OrdersProductsConfigurableField property SelectBoxOptions.

### DIFF
--- a/BigCommerce4Net.Domain/Entities/Orders/OrdersProductsConfigurableField.cs
+++ b/BigCommerce4Net.Domain/Entities/Orders/OrdersProductsConfigurableField.cs
@@ -102,6 +102,6 @@ namespace BigCommerce4Net.Domain
         /// ?string(255)
         /// </summary>
         [JsonProperty("select_box_options")]
-        public virtual string SelectBoxOptions { get; set; }
+        public virtual List<string> SelectBoxOptions { get; set; }
     }
 }


### PR DESCRIPTION
Changed SelectBoxOptions's data type to 'List<string>'.

Fixes error thrown when OrderProducts contains 'configurable_fields'.

https://github.com/worstone/BigCommerce4Net/issues/16