### PR TITLE
Add PaymentStatus value "Pending"

### DIFF
--- a/BigCommerce4Net.Domain/Entities/Orders/Order.cs
+++ b/BigCommerce4Net.Domain/Entities/Orders/Order.cs
@@ -277,6 +277,7 @@ namespace BigCommerce4Net.Domain
         /// captured
         /// refunded
         /// partially
+        /// pending
         /// refunded
         /// voided
         /// </summary>

--- a/BigCommerce4Net.Domain/Enumerations/PaymentStatus.cs
+++ b/BigCommerce4Net.Domain/Enumerations/PaymentStatus.cs
@@ -42,6 +42,9 @@ namespace BigCommerce4Net.Domain
         PartiallyRefunded = 4,
         
         [EnumMember(Value = "void")]
-        Voided = 5
+        Voided = 5,
+        
+        [EnumMember(Value = "pending")]
+        Pending = 6
     }
 }


### PR DESCRIPTION
I ran into a problem getting orders that have a payment_status of "pending". Below is an excerpt of the exception I found in the RestResponse returned from Orders.get().

"ErrorException": {
      "ClassName": "BigCommerce4Net.Api.NewtonSoftJsonDeserializerException",
      "Message": "Error converting value \"pending\" to type 'BigCommerce4Net.Domain.PaymentStatus'. Path 'payment_status', line 1, position 950.",
}

Adding an EnumMember to handle "pending" resolves this issue.

More info if you're interested:
I have only recently come across this "pending" status on orders paid with PayPal Express and an order status of Awaiting Payment (7). 

This bug has the potential to getting a list of orders. For example I had a few dozen Awaiting Payment orders to process. When calling Orders.Get with a filter of status_id = 7 the response Data was **null** but the response content was the big ol' JSON response from BigCommerce which contained all the order data.